### PR TITLE
Fix screen touch not triggering

### DIFF
--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -340,6 +340,8 @@ export default class VideoPlayer extends Component {
   _onVideoPress() {
     if (typeof this.props.onVideoPress === 'function') {
       this.props.onVideoPress();
+    } else {
+      this.events.onScreenTouch();
     }
   }
 


### PR DESCRIPTION
The component was organized to allow for separation of video and controls' `onClick` functions. This caused the `onScreenTouch` to not trigger after the video has loaded. This fix allows the player to detect screen touches when no specific `onVideoPress` function is provided.